### PR TITLE
Changing name check to use D#+ utilities

### DIFF
--- a/DSharpPlus.SlashCommands/Attributes/OptionAttribute.cs
+++ b/DSharpPlus.SlashCommands/Attributes/OptionAttribute.cs
@@ -32,9 +32,7 @@ namespace DSharpPlus.SlashCommands
 		public OptionAttribute(string name, string description, bool autocomplete = false)
 		{
 			if (!Utilities.IsValidSlashCommandName(name))
-			{
 				throw new ArgumentException("Invalid slash command name specified. It must be below 32 characters and not contain any whitespace.", "name");
-			}
 			if (description.Length > 100)
 				throw new ArgumentException("Slash command option descriptions cannot go over 100 characters.");
 			

--- a/DSharpPlus.SlashCommands/Attributes/OptionAttribute.cs
+++ b/DSharpPlus.SlashCommands/Attributes/OptionAttribute.cs
@@ -31,10 +31,13 @@ namespace DSharpPlus.SlashCommands
 		/// <param name="autocomplete">Whether this option should autocomplete.</param>
 		public OptionAttribute(string name, string description, bool autocomplete = false)
 		{
-			if (name.Length > 32)
-				throw new ArgumentException("Slash command option names cannot go over 32 characters.");
+			if (!Utilities.IsValidSlashCommandName(name))
+			{
+				throw new ArgumentException("Invalid slash command name specified. It must be below 32 characters and not contain any whitespace.", "name");
+			}
 			if (description.Length > 100)
 				throw new ArgumentException("Slash command option descriptions cannot go over 100 characters.");
+			
 			Name = name.ToLower();
 			Description = description;
 			Autocomplete = autocomplete;


### PR DESCRIPTION
Changed the check for the option name to use the D#+ built in check. That's it.