### PR TITLE
Add missing DefaultPermissions and GuildOnly values from attribute for SlashCommandGroups

### DIFF
--- a/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
+++ b/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
@@ -71,7 +71,9 @@ namespace DSharpPlus.SlashCommands
 
 				ApplicationCommandBuilder command = new ApplicationCommandBuilder(ApplicationCommandType.SlashCommand)
 					.WithName(gAttr.Name)
-					.WithDescription(gAttr.Description);
+					.WithDescription(gAttr.Description)
+					.WithDefaultPermissions(gAttr.DefaultPermissions)
+					.WithGuildOnly(gAttr.GuildOnly);
 
 				if (gAttr.ApplyLocalization)
 				{
@@ -177,7 +179,9 @@ namespace DSharpPlus.SlashCommands
 					ApplicationCommandBuilder command =
 						new ApplicationCommandBuilder(ApplicationCommandType.SlashCommand)
 							.WithName(gAttr.Name)
-							.WithDescription(gAttr.Description);
+							.WithDescription(gAttr.Description)
+							.WithDefaultPermissions(gAttr.DefaultPermissions)
+							.WithGuildOnly(gAttr.GuildOnly);
 
 					if (gAttr.ApplyLocalization)
 					{


### PR DESCRIPTION
Back a few days ago when I was trying to get GuildOnly commands to work, 
I noticed that DefaultPermissions and GuildOnly values from the SlashCommandGroupAttribute was not being used. This fixed it for me.